### PR TITLE
fix importdocs and requirements

### DIFF
--- a/2024-09-10-buildrag/python/importdocs.py
+++ b/2024-09-10-buildrag/python/importdocs.py
@@ -8,9 +8,12 @@ chromaclient = chromadb.HttpClient(host="localhost", port=8000)
 textdocspath = "../../scripts"
 text_data = readtextfiles(textdocspath)
 
-collection = chromaclient.get_or_create_collection(name="buildragwithpython", metadata={"hnsw:space": "cosine"}  )
+collectionname = "buildragwithpython"
 if any(collection.name == collectionname for collection in chromaclient.list_collections()):
-  chromaclient.delete_collection("buildragwithpython")
+  chromaclient.delete_collection(collectionname)
+
+collection = chromaclient.get_or_create_collection(name=collectionname, metadata={"hnsw:space": "cosine"}  )
+
 
 for filename, text in text_data.items():
   chunks = chunksplitter(text)

--- a/2024-09-10-buildrag/python/requirements.txt
+++ b/2024-09-10-buildrag/python/requirements.txt
@@ -1,3 +1,2 @@
 chromadb
-os
-re
+ollama


### PR DESCRIPTION
this PR fixes the issues with:
- importdocs.py: collectionname is not defined 
- requirements.txt: no need to define build-in packages (os, re). ollama package is missing

